### PR TITLE
fix: crash on resize

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,10 +12,8 @@
     "linux"
   ],
   "permissions": [
-    "core:default",
     "core:window:allow-set-size",
     "core:window:allow-start-dragging",
-    "core:window:deny-maximize",
     "core:app:default",
     "core:event:default",
     "shell:default"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,49 +1,56 @@
 #![cfg_attr(
-  all(not(debug_assertions), target_os = "windows"),
-  windows_subsystem = "windows"
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
 )]
 
 use tauri::{AppHandle, Manager, WebviewWindow};
 use tauri_nspanel::{panel_delegate, WebviewWindowExt};
 
 pub fn run() {
-  tauri::Builder::default()
-    .plugin(tauri_nspanel::init())
-    .setup(|app| {
-      init(app.app_handle());
+    tauri::Builder::default()
+        .plugin(tauri_nspanel::init())
+        .setup(|app| {
+            init(app.app_handle());
 
-      Ok(())
-    })
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }
 
 fn init(app_handle: &AppHandle) {
-  let window: WebviewWindow = app_handle.get_webview_window("main").unwrap();
+    let window: WebviewWindow = app_handle.get_webview_window("main").unwrap();
 
-  let panel = window.to_panel().unwrap();
+    let panel = window.to_panel().unwrap();
 
-  let delegate = panel_delegate!(MyPanelDelegate {
-    window_did_become_key,
-    window_did_resign_key
-  });
+    let delegate = panel_delegate!(MyPanelDelegate {
+        window_did_become_key,
+        window_did_resign_key
+    });
 
-  let handle = app_handle.to_owned();
+    let handle = app_handle.to_owned();
 
-  delegate.set_listener(Box::new(move |delegate_name: String| {
-    match delegate_name.as_str() {
-      "window_did_become_key" => {
-        let app_name = handle.package_info().name.to_owned();
+    delegate.set_listener(Box::new(move |delegate_name: String| {
+        match delegate_name.as_str() {
+            "window_did_become_key" => {
+                let app_name = handle.package_info().name.to_owned();
 
-        println!("[info]: {:?} panel becomes key window!", app_name);
-      }
-      "window_did_resign_key" => {
-        println!("[info]: panel resigned from key window!");
-      }
-      _ => (),
-    }
-  }));
+                println!("[info]: {:?} panel becomes key window!", app_name);
+            }
+            "window_did_resign_key" => {
+                println!("[info]: panel resigned from key window!");
+            }
+            _ => (),
+        }
+    }));
 
-  panel.set_delegate(delegate);
+    // 1. Define a non activating window style mask
+
+    #[allow(non_upper_case_globals)]
+    pub const NSWindowStyleMaskNonActivatingPanel: i32 = 1 << 7;
+
+    // 2. Prevents the panel from activating the app
+    panel.set_style_mask(NSWindowStyleMaskNonActivatingPanel);
+
+    panel.set_delegate(delegate);
 }
-

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,10 +47,13 @@ fn init(app_handle: &AppHandle) {
     // 1. Define a non activating window style mask
 
     #[allow(non_upper_case_globals)]
-    pub const NSWindowStyleMaskNonActivatingPanel: i32 = 1 << 7;
+    const NSWindowStyleMaskNonActivatingPanel: i32 = 1 << 7;
+
+    #[allow(non_upper_case_globals)]
+    const NSResizableWindowMask: i32 = 1 << 3;
 
     // 2. Prevents the panel from activating the app
-    panel.set_style_mask(NSWindowStyleMaskNonActivatingPanel);
+    panel.set_style_mask(NSWindowStyleMaskNonActivatingPanel | NSResizableWindowMask);
 
     panel.set_delegate(delegate);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,21 @@
 import "./App.css";
 
 function App() {
-
   return (
     <div data-tauri-drag-region className="container">
-      <h1 data-tauri-drag-region style={{ display: "flex", alignItems: "center", justifyContent: "center", height: 80, width: "100%", backgroundColor: "black" }}>Double Click Me!</h1>
-
+      <h1
+        data-tauri-drag-region
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: 80,
+          width: "100%",
+          backgroundColor: "black",
+        }}
+      >
+        Double Click Me!
+      </h1>
     </div>
   );
 }


### PR DESCRIPTION
the `core:default` which is supposed to prelude commonly used events seems to be the culprit.

i think it's enforcing allowing maximise event.

removing it fixes the issue. 

that explains why menote's editor panel did not crash,  I wasn't using `core:default`, I was explicit with the  permissions list.
